### PR TITLE
#25 - Solo hacer scroll en lista de perros

### DIFF
--- a/src/app/features/patients/patients.html
+++ b/src/app/features/patients/patients.html
@@ -1,10 +1,11 @@
 <div class="flex flex-col">
-    <div class="flex flex-col gap-1">
-        <h1 class="text-2xl font-bold text-neutral">Gestión de Pacientes</h1>
-        <p class="text-sm text-muted">Consulta y filtra la lista de pacientes.</p>
-    </div>
+    <div class="sticky top-[-1.5rem] z-10 pt-6 pb-4 bg-main">
+        <div class="flex flex-col gap-1">
+            <h1 class="text-2xl font-bold text-neutral">Gestión de Pacientes</h1>
+            <p class="text-sm text-muted">Consulta y filtra la lista de pacientes.</p>
+        </div>
 
-    <div class="sticky top-0 z-10 pt-2 pb-4 bg-main">
+
         <div class="flex flex-col md:flex-row items-center gap-4 w-full">
             <div class="flex-1 w-full">
                 <p-iconfield iconPosition="left">


### PR DESCRIPTION
Por una decisión de diseño, se ocultaba el título de la pagina para aprovechar mas espacio de pantalla.


https://github.com/user-attachments/assets/0d2cac53-52c1-4dbb-b022-3bf53347a0df


Se realizó el cambio solicitado para que quede fijado todo el bloque del header de la sección.


https://github.com/user-attachments/assets/16f91194-59c6-4de4-9d6c-27a3b6383d74




