### PR TITLE
#26 - Remover delay

### DIFF
--- a/src/app/features/patients/patients.ts
+++ b/src/app/features/patients/patients.ts
@@ -80,7 +80,7 @@ export class Patients implements OnInit {
     this.loading = true;
     this.errorMessage = null;
 
-    this.patientsService.getPatients().pipe(delay(2000)).subscribe({
+    this.patientsService.getPatients().subscribe({
       next: (data) => {
         this.patients = data;
         this.filteredPatients = [...data];


### PR DESCRIPTION
Se eliminó el delay al realizar la carga de perros. Se había puesto por un error de interpretación de la consigna, pensando que si o si se tenia que ver el spinner en cada carga.